### PR TITLE
Add basic tests for flow manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ flow_manager.schedule_flow('parent', 3600)
 flow_manager.create_flow_from_ai('ai-generated', 'Create a video loop and upload it')
 ```
 
+## Running Tests
+
+The test suite uses [busted](https://olivinelabs.com/busted/) to verify basic
+flow management features. After installing `busted`, run:
+
+```sh
+busted tests
+```
+
 # License Overview
 
 This project is generously offered under a dual-license model, designed to accommodate both open-source community projects and commercial initiatives. Our goal is to foster innovation and collaboration while also supporting the project's sustainable development.

--- a/tests/flow_manager_spec.lua
+++ b/tests/flow_manager_spec.lua
@@ -1,0 +1,35 @@
+package.path = package.path .. ';./lua/?.lua;./lua/?/init.lua'
+
+local flow_manager = require('alchemy.modules.flow_manager')
+
+before_each(function()
+  -- Stop any running timers and reset flows
+  for name, flow in pairs(flow_manager.flows) do
+    for _, timer in ipairs(flow.timers or {}) do
+      timer:stop()
+      timer:close()
+    end
+  end
+  flow_manager.flows = {}
+end)
+
+describe('flow_manager', function()
+  it('creates a flow', function()
+    flow_manager.create_flow('test', {})
+    assert.is_truthy(flow_manager.flows['test'])
+  end)
+
+  it('invokes a flow', function()
+    local called = false
+    flow_manager.create_flow('invoke', { run = function() called = true end })
+    flow_manager.run_flow('invoke')
+    assert.is_true(called)
+  end)
+
+  it('schedules a flow', function()
+    flow_manager.create_flow('scheduled', {})
+    flow_manager.schedule_flow('scheduled', 0)
+    assert.is_true(#flow_manager.flows['scheduled'].timers > 0)
+    flow_manager.stop_schedules('scheduled')
+  end)
+end)


### PR DESCRIPTION
## Summary
- add a small busted suite for flow creation, invocation, and scheduling
- document how to run tests

## Testing
- `busted tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a2f11c30833388d6e14e0e13f0a2